### PR TITLE
Integrating makani model package with earth2mip

### DIFF
--- a/networks/model_package.py
+++ b/networks/model_package.py
@@ -208,6 +208,7 @@ def load_time_loop(package, device=None, time_step_hours=None):
     # https://gitlab-master.nvidia.com/modulus/earth-2/earth2-mip
     from earth2mip.networks import Inference
     from earth2mip.schema import Grid
+    import earth2mip
     config = package.get("config.json")
     params = ParamsBase.from_json(config)
 
@@ -266,7 +267,7 @@ def load_time_loop(package, device=None, time_step_hours=None):
         channel_names=names,
         center=center,
         scale=scale,
-        grid=grid,
+        grid=earth2mip.grid.from_enum(grid),
         n_history=params.n_history,
         time_step=time_step,
     )


### PR DESCRIPTION
In order to use a model package output by makani with earth2mip, the grid must be in the correct form.  In the existing code, when trying to integrate the model package with earth2mip, I get an error 

```
Traceback (most recent call last):
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/site-packages/earth2mip/inference_ensemble.py", line 411, in <module>
    main()
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/site-packages/earth2mip/inference_ensemble.py", line 206, in main
    run_inference(model, config, perturb, group)
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/site-packages/earth2mip/inference_ensemble.py", line 334, in run_inference
    x = initial_conditions.get_initial_condition_for_model(model, data_source, date_obj)
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/site-packages/earth2mip/initial_conditions/__init__.py", line 71, in get_initial_condition_for_model
    regridder = regrid.get_regridder(data_source.grid, time_loop.grid).to(
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/site-packages/earth2mip/regrid.py", line 85, in get_regridder
    return RegridLatLon(src, dest)
  File "/global/common/software/m4416/fcn_mip-env/lib/python3.10/site-packages/earth2mip/regrid.py", line 65, in __init__
    self._lat_index = pandas.Index(src_grid.lat).get_indexer(dest_grid.lat)
AttributeError: 'Grid' object has no attribute 'lat'
```

The pull request fixes this issue and enables generating output from makani models with earth2mip!