### PR TITLE
Removing numpy upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dynamic = ["version"]
 
 dependencies = [
     "torch>=2.0.0",
-    "numpy>=1.22.4,<1.25",
+    "numpy>=1.22.4",
     "numba>=0.50.0",
     "nvidia_dali_cuda110>=1.16.0",
     "nvidia-modulus>=0.5.0a0",


### PR DESCRIPTION
Fix install for Python 3.12

Same deal https://github.com/NVIDIA/torch-harmonics/issues/58